### PR TITLE
Resolved SyntaxError: Block-scoped declarations 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var path = require('path');
 var glob = require('glob');
 var swig = require('swig');


### PR DESCRIPTION
Resolution of Block-scoped declaration

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:373:25)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/Users/username/Documents/Directory/Project/develop/APP/webpack.config.js:5:18)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
